### PR TITLE
fixed DEF_THREADS = 0 on Android due to node.js os.cpus().length not …

### DIFF
--- a/source/cbae.js
+++ b/source/cbae.js
@@ -37,7 +37,7 @@ import {cdinfos} from './cdinfos.js';
 // L.set({ date: "", level: 4, file: "/tmp/log_cbae.txt", pos: true, stderr: true });
 
 // Use 3/4 of total threads for operations
-const DEF_THREADS = Math.ceil(cpus().length * 0.75);
+const DEF_THREADS = (Math.ceil(cpus().length * 0.75)) || 1;
 
 // -------------------------------------------------------;
 


### PR DESCRIPTION
caused by number of encoding threads DEF_THREADS=0
node.js os.cpus().length not returning number
of cpu cores on Android / Termux
Issue #4